### PR TITLE
Limit M2 to 2.3.5-p2

### DIFF
--- a/m23_config/Dockerfile
+++ b/m23_config/Dockerfile
@@ -1,7 +1,7 @@
 FROM mike/debian_config
 MAINTAINER chandlerbing7@gmail.com
 
-RUN composer create-project --repository=https://repo.magento.com/ magento/project-community-edition /var/www/html/magento2ce/
+RUN composer create-project --repository=https://repo.magento.com/ magento/project-community-edition/2.3.5-p2 /var/www/html/magento2ce/
 #RUN composer create-project --repository=https://repo.magento.com/ magento/project-enterprise-edition /var/www/html/magento2ce/
 RUN mkdir /var/www/html/magento2ce/var/composer_home/
 RUN touch /var/www/html/magento2ce/var/composer_home/auth.json

--- a/m23_config/Dockerfile
+++ b/m23_config/Dockerfile
@@ -1,7 +1,7 @@
 FROM mike/debian_config
 MAINTAINER chandlerbing7@gmail.com
 
-RUN composer create-project --repository=https://repo.magento.com/ magento/project-community-edition/2.3.5-p2 /var/www/html/magento2ce/
+RUN composer create-project --repository=https://repo.magento.com/ magento/project-community-edition=2.3.5-p2 /var/www/html/magento2ce/
 #RUN composer create-project --repository=https://repo.magento.com/ magento/project-enterprise-edition /var/www/html/magento2ce/
 RUN mkdir /var/www/html/magento2ce/var/composer_home/
 RUN touch /var/www/html/magento2ce/var/composer_home/auth.json


### PR DESCRIPTION
Since 2.4 came out, the install fails due to the version of PHP, elastic, etc. This limits it to 2.3.5-p2.