### PR TITLE
Remove use of winpty on Windows

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -95,7 +95,7 @@ docker exec -ti m23 /bin/bash
 
 _Windows_
 ```
-winpty docker exec -it m23 //bin/sh
+docker exec -it m23 //bin/sh
 ```
 
 **Getting Access to the Magento instance**
@@ -227,7 +227,7 @@ docker exec -ti <CONTAINER_ID> /bin/bash
 
 _Windows_
 ```
-winpty docker exec -it <CONTAINER_ID> //bin/sh
+docker exec -it <CONTAINER_ID> //bin/sh
 ```
 
 Example:
@@ -239,7 +239,7 @@ docker exec -ti m23 /bin/bash
 
 Windows:
 ```
-winpty docker exec -it m23 //bin/sh
+docker exec -it m23 //bin/sh
 ```
 
 To stop the VM, use the following command:

--- a/debian_config/Dockerfile
+++ b/debian_config/Dockerfile
@@ -1,33 +1,31 @@
-FROM debian:latest
+FROM ubuntu:20.04
+
 
 #ARG AUTH_JSON
 
 # System
-RUN	apt update
+ENV TZ=America/Toronto \
+    DEBIAN_FRONTEND=noninteractive
+RUN	apt update -y
 RUN apt install -y 	curl nano vim sendmail cron locate
-RUN echo "127.0.0.1 localhost magento2u.loc" >> /etc/hosts
 
 # Apache
 RUN apt install -y 	apache2 \
 						libapache2-mod-php && \
-						apt-get clean
+						apt clean
 # PHP
-RUN apt install apt-transport-https lsb-release ca-certificates -y ; \
-    apt install mc -y ; \
-	apt install wget -y ; \
-	wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg ; \
-	echo 	"deb https://packages.sury.org/php/ $(lsb_release -sc) main" > \
-			/etc/apt/sources.list.d/php.list ; \
-	apt update ; apt install php7.3 -y
-RUN	apt install -y 	php7.3-bcmath php7.3-bz2 php7.3-cli php7.3-common \
+RUN apt install -y software-properties-common && \
+	add-apt-repository ppa:ondrej/php && \
+	apt update -y && \
+	apt install -y 	php7.3 php7.3-bcmath php7.3-bz2 php7.3-cli php7.3-common \
 					php7.3-curl php7.3-dba php7.3-gd php7.3-gmp php7.3-imap \
 					php7.3-intl php7.3-ldap php7.3-mbstring  \
 					php7.3-mysql php7.3-odbc php7.3-pgsql php7.3-recode \
-					php7.3-snmp php7.3-soap php7.3-sqlite php7.3-tidy \
+					php7.3-snmp php7.3-soap php7.3-tidy \
 					php7.3-xml php7.3-xmlrpc php7.3-xsl php7.3-zip
 
 # Create user and assign to web server group
-#RUN adduser magento
+RUN adduser --disabled-password --gecos '' magento
 RUN usermod -aG root www-data
 #
 #ENV APACHE_RUN_USER     magento
@@ -45,14 +43,15 @@ RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
 RUN a2enmod rewrite ; \
 	a2enmod mpm_prefork
 
-RUN update-alternatives --set php /usr/bin/php7.3 ; \
-	a2dismod php7.0 ; a2enmod php7.3 ; service apache2 restart
+RUN update-alternatives --set php /usr/bin/php7.3 && \
+	a2dismod php7.0 ; a2enmod php7.3 && \
+	service apache2 restart
 
 #COPY ./conf/php.ini /etc/php/7.1/apache2/php.ini
 COPY ./conf/php.ini /etc/php/7.3/apache2/php.ini
 
 # MySQL
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y mariadb-server
+RUN apt update -y && apt install -y mariadb-server
 RUN /etc/init.d/mysql start && \
         mysql -u root -e \
         "use mysql;update user set plugin='' where User='root'; \
@@ -81,7 +80,7 @@ RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 # Git
 RUN apt install -y git
 
-RUN apt --purge autoremove -y ; apt clean
+RUN apt --purge autoremove -y && apt clean -y
 
 # .bash_profile
 COPY ./user/bashrc.txt /root/.bashrc

--- a/debian_config/conf/000-default.conf
+++ b/debian_config/conf/000-default.conf
@@ -9,9 +9,9 @@
     #ServerName www.example.com
 
     ServerAdmin webmaster@localhost
-    DocumentRoot /var/www/html/shared/magento2ce/pub/
+    DocumentRoot /var/www/html/magento2ce/pub/
     
-    <Directory /var/www/html/shared/magento2ce/pub/>
+    <Directory /var/www/html/magento2ce/pub/>
     Options FollowSymLinks MultiViews
     AllowOverride All
     Order allow,deny

--- a/debian_config/user/bashrc.txt
+++ b/debian_config/user/bashrc.txt
@@ -21,4 +21,4 @@
 # setup shell
 export PS1="\[\033[36m\]\u\[\033[m\]@\[\033[32m\]\h:\[\033[33;1m\]\w\[\033[m\]\$ "
 
-alias m2="cd /var/www/html/shared/magento2ce"
+alias m2="cd /var/www/html/magento2ce"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 
 services:
   base:
@@ -9,16 +9,29 @@ services:
   m23:
     build: ./m23_config/
     image: mike/m23_config
+    extra_hosts:
+      - "magento2u.loc:127.0.0.1"
     depends_on:
       - base
     ports:
       - "8080:80"
       - "4306:3306"
     volumes:
-#       - /Path/To/Your/magento/magento2-dev-dk/instances:/var/www/html/shared
-#       - /Users/molochko/Sites/magento/magento2-dev-dk/instances:/var/www/html/shared
-       - src-volume-dk:/var/www/html/shared
+      #       - /Path/To/Your/magento/magento2-dev-dk/instances:/var/www/html/shared
+      #       - /Users/molochko/Sites/magento/magento2-dev-dk/instances:/var/www/html/shared
+      - src-volume-dk:/var/www/html/shared
     tty: true
     container_name: m23
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin
+    container_name: phpmyadmin
+    environment:
+      - PMA_HOST=m23
+      - PMA_USER=magento
+      - PMA_PASSWORD=magento
+    ports:
+      - 8088:80
+    depends_on:
+      - m23
 volumes:
   src-volume-dk:

--- a/m23_config/Dockerfile
+++ b/m23_config/Dockerfile
@@ -31,6 +31,7 @@ RUN /etc/init.d/mysql start && \
     composer require --dev n98/magerun2-dist
 
 RUN chown -R www-data:www-data /var/www/html/magento2ce/
+RUN chmod -R 755 /var/www/html/magento2ce/pub
 
 RUN apt --purge autoremove -y ; apt clean
 

--- a/m23_config/bin/console
+++ b/m23_config/bin/console
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 
-PATHS="/var/www/html/shared/magento2ce"
+PATHS="/var/www/html/magento2ce"
 
 execute() {
     docker-compose exec m23 php $PATHS/bin/magento $*


### PR DESCRIPTION
winpty is not necessary with new Docker installations, as long as the executables are added to path